### PR TITLE
Beginner rtt blocking

### DIFF
--- a/boards/dk/src/lib.rs
+++ b/boards/dk/src/lib.rs
@@ -178,9 +178,9 @@ pub fn init() -> Result<Board, ()> {
         // NOTE this must be executed as early as possible or the tool will timeout
         // NOTE the unsafety of this macro is incorrect; it must be run at most once
         #[cfg(feature = "beginner")]
-        rtt_init_print!(BlockIfFull, 4096);
+        rtt_init_print!(BlockIfFull, 16384);
         #[cfg(feature = "advanced")]
-        rtt_init_print!(NoBlockSkip, 4096);
+        rtt_init_print!(NoBlockSkip, 16384);
 
         log::set_logger(&Logger).unwrap();
 

--- a/tools/dk-run/src/main.rs
+++ b/tools/dk-run/src/main.rs
@@ -195,7 +195,7 @@ fn notmain() -> Result<i32, anyhow::Error> {
     let rtt_addr_res = rtt_addr.ok_or_else(|| anyhow!("RTT control block not available"))?;
     let mut rtt_res: Result<Rtt, probe_rs_rtt::Error> =
         Err(probe_rs_rtt::Error::ControlBlockNotFound);
-    const NUM_RETRIES: usize = 3; // picked at random, increase if necessary
+    const NUM_RETRIES: usize = 5; // picked at random, increase if necessary
 
     for try_index in 0..=NUM_RETRIES {
         rtt_res = Rtt::attach_region(core.clone(), &sess, &ScanRegion::Exact(rtt_addr_res));


### PR DESCRIPTION
notes:
- increasing the buffer dramatically (i.e. to 16k) will make the rtt-attach dramatically slower (3 retries weren't enough with `hello.rs` on `opt-level = 0`) so I doubled it
- got a warning that "attributes on expressions are experimental" so I opted for the duplicated-but-actually-shorter option instead of doing something similar to
```rust
let mode: rtt_target::ChannelMode;

#[cfg(feature = "beginner")]
mode = ChannelMode::BlockIfFull;
#[cfg(feature = "advanced")]
mode = ChannelMode::NoBlockSkip;

rtt_init_print!(mode, 4096);
```