### PR TITLE
radio-send.rs: run cargo fmt

### DIFF
--- a/beginner/apps/src/bin/radio-send.rs
+++ b/beginner/apps/src/bin/radio-send.rs
@@ -3,7 +3,7 @@
 #![no_std]
 
 use cortex_m_rt::entry;
-use dk::ieee802154::{Packet, Channel, TxPower};
+use dk::ieee802154::{Channel, Packet, TxPower};
 use panic_log as _; // the panicking behavior
 
 #[entry]


### PR DESCRIPTION
drive-by fix: `radio-send.rs` kept cluttering my git output after I ran `cargo fmt` in `beginner/apps/src/bin/` to clean up the puzzle code I'd just written which was confusing at first. This PR makes sure `radio-send` is correct right away.