### PR TITLE
CI: add cargo fmt

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,12 +51,18 @@ jobs:
 
     - name: build tools
       working-directory: ./tools
-      run: cargo build --verbose
+      run: |
+        cargo build --verbose
+        cargo fmt --all -- --check
 
-    - name: build beginner/apps
+    - name: build and fmt beginner/apps
       working-directory: ./beginner/apps
-      run: cargo build --verbose
+      run: |
+        cargo build --verbose
+        cargo fmt --all -- --check
 
-    - name: build advanced/firmware
+    - name: build and fmt advanced/firmware
       working-directory: ./advanced/firmware
-      run: cargo build --verbose
+      run: |
+        cargo build --verbose
+        cargo fmt --all -- --check

--- a/advanced/firmware/src/bin/usb-2-solution.rs
+++ b/advanced/firmware/src/bin/usb-2-solution.rs
@@ -44,7 +44,6 @@ fn on_event(usbd: &USBD, event: Event) {
         Event::UsbEp0DataDone => todo!(),
 
         Event::UsbEp0Setup => {
-
             // the BMREQUESTTYPE register contains information about data recipient, transfer type and direction
             let bmrequesttype = usbd.bmrequesttype.read().bits() as u8;
             // the BREQUEST register stores the type of the current request (e.g. SET_ADDRESS, GET_DESCRIPTOR, ...)


### PR DESCRIPTION
tested (and reverted the changes that introduced formatting changes for testing)

also fixes a formatting violation as a drive-by