### PR TITLE
Fix unclarity in USB-3

### DIFF
--- a/embedded-workshop-book/src/data-stage.md
+++ b/embedded-workshop-book/src/data-stage.md
@@ -8,7 +8,7 @@ The `Ep0In` API has two methods: `start` and `end` (also see their API documenta
 
 To implement responding to a GET_DESCRIPTOR request, do the following:
 
-1. **Extend the parser implementation to handle a GET_DESCRIPTOR request:** make the `common/usb/lib.rs::get_descriptor_configuration()` test run successfully.
+1. **Extend the GET_DESCRIPTOR parser implementation to handle a CONFIGURATION request:** make the `common/usb/lib.rs::get_descriptor_configuration()` test run successfully.
 2. **Answer the Descriptor Request:** extend `usb-3.rs` so that it uses `Ep0In` to respond to the `GET_DESCRIPTOR Device` request (and only to that request). The response must be a device descriptor with its fields set to these values:
 
 - `bDeviceClass = bDeviceSubClass = bDeviceProtocol = 0`, these are unimportant for enumeration


### PR DESCRIPTION
USB-2 already implements GET_DESCRIPTOR, make clear that it must be extended