### PR TITLE
rename USB parser solutions

### DIFF
--- a/advanced/common/usb/solution-get-descriptor-configuration.rs
+++ b/advanced/common/usb/solution-get-descriptor-configuration.rs
@@ -1,5 +1,5 @@
 //! Some USB 2.0 data types
-// NOTE this is a solution to exercise `usb-2`
+// NOTE this is a partial solution to exercise `usb-3`
 
 #![deny(missing_docs)]
 #![deny(warnings)]
@@ -24,7 +24,6 @@ pub enum Request {
 
     /// SET_ADDRESS
     // see section 9.4.6 of the USB specification
-    #[cfg(TODO)]
     SetAddress {
         /// New device address, in the range `1..=127`
         address: Option<Address>,
@@ -32,6 +31,7 @@ pub enum Request {
 
     /// SET_CONFIGURATION
     // see section 9.4.7 of the USB specification
+    #[cfg(TODO)]
     SetConfiguration {
         /// bConfigurationValue to change the device to
         value: Option<NonZeroU8>,
@@ -51,13 +51,14 @@ impl Request {
         windex: u16,
         wlength: u16,
     ) -> Result<Self, ()> {
-        // see table 9-4
+        // see table 9-4 (USB specification)
+        const SET_ADDRESS: u8 = 5;
         const GET_DESCRIPTOR: u8 = 6;
-        const SET_CONFIGURATION: u8 = 9;
 
         if bmrequesttype == 0b10000000 && brequest == GET_DESCRIPTOR {
             // see table 9-5
             const DEVICE: u8 = 1;
+            const CONFIGURATION: u8 = 2;
 
             let desc_ty = (wvalue >> 8) as u8;
             let desc_index = wvalue as u8;
@@ -68,13 +69,22 @@ impl Request {
                     descriptor: Descriptor::Device,
                     length: wlength,
                 })
+            } else if desc_ty == CONFIGURATION && langid == 0 {
+                Ok(Request::GetDescriptor {
+                    descriptor: Descriptor::Configuration { index: desc_index },
+                    length: wlength,
+                })
             } else {
                 Err(())
             }
-        } else if bmrequesttype == 0b00000000 && brequest == SET_CONFIGURATION {
-            if wvalue < 256 && windex == 0 && wlength == 0 {
-                Ok(Request::SetConfiguration {
-                    value: NonZeroU8::new(wvalue as u8),
+        } else if bmrequesttype == 0b00000000 && brequest == SET_ADDRESS {
+            // Set the device address for all future accesses.
+            // (Needed to successfully init when conected to Apple devices)
+            // Section 9.4.6 Set Address of the USB specification explains which values for wvalue,
+            // windex and wlength are valid.
+            if wvalue < 128 && windex == 0 && wlength == 0 {
+                Ok(Request::SetAddress {
+                    address: NonZeroU8::new(wvalue as u8),
                 })
             } else {
                 Err(())
@@ -92,7 +102,6 @@ pub enum Descriptor {
     Device,
 
     /// Configuration descriptor
-    #[cfg(TODO)]
     Configuration {
         /// Index of the descriptor
         index: u8,
@@ -126,24 +135,6 @@ mod tests {
         //                                                 ^^^^
     }
 
-    #[cfg(TODO)]
-    #[test]
-    fn get_descriptor_configuration() {
-        // OK: GET_DESCRIPTOR Configuration 0 [length=9]
-        assert_eq!(
-            Request::parse(0b1000_0000, 0x06, 0x02_00, 0, 9),
-            Ok(Request::GetDescriptor {
-                descriptor: Descriptor::Configuration { index: 0 },
-                length: 9
-            })
-        );
-
-        // has language ID but shouldn't
-        assert!(Request::parse(0b1000_0000, 0x06, 0x02_00, 1033, 9).is_err());
-        //                                                 ^^^^
-    }
-
-    #[cfg(TODO)]
     #[test]
     fn set_address() {
         // OK: SET_ADDRESS 16
@@ -173,6 +164,23 @@ mod tests {
         //                                                    ^
     }
 
+    #[test]
+    fn get_descriptor_configuration() {
+        // OK: GET_DESCRIPTOR Configuration 0 [length=9]
+        assert_eq!(
+            Request::parse(0b1000_0000, 0x06, 0x02_00, 0, 9),
+            Ok(Request::GetDescriptor {
+                descriptor: Descriptor::Configuration { index: 0 },
+                length: 9
+            })
+        );
+
+        // has language ID but shouldn't
+        assert!(Request::parse(0b1000_0000, 0x06, 0x02_00, 1033, 9).is_err());
+        //                                                 ^^^^
+    }
+
+    #[cfg(TODO)]
     #[test]
     fn set_configuration() {
         // OK: SET_CONFIGURATION 1

--- a/advanced/common/usb/solution-get-descriptor-configuration.rs
+++ b/advanced/common/usb/solution-get-descriptor-configuration.rs
@@ -1,5 +1,5 @@
 //! Some USB 2.0 data types
-// NOTE this is a partial solution to exercise `usb-3`
+// NOTE this is a partial solution to exercise `usb-4`
 
 #![deny(missing_docs)]
 #![deny(warnings)]

--- a/advanced/common/usb/solution-get-descriptor-device.rs
+++ b/advanced/common/usb/solution-get-descriptor-device.rs
@@ -1,5 +1,5 @@
 //! Some USB 2.0 data types
-// NOTE this is a solution to exercise `usb-3`
+// NOTE this is a partial solution to exercise `usb-2`
 
 #![deny(missing_docs)]
 #![deny(warnings)]
@@ -55,23 +55,23 @@ impl Request {
         const SET_ADDRESS: u8 = 5;
         const GET_DESCRIPTOR: u8 = 6;
 
+
         if bmrequesttype == 0b10000000 && brequest == GET_DESCRIPTOR {
             // see table 9-5
             const DEVICE: u8 = 1;
-            const CONFIGURATION: u8 = 2;
 
+            // 1. get descriptor type and descriptor index from wValue
             let desc_ty = (wvalue >> 8) as u8;
             let desc_index = wvalue as u8;
             let langid = windex;
 
+            // 2. confirm that the descriptor
+            //    - is of type DEVICE and
+            //    - has descriptor index 0 (i.e. it is the first implemented descriptor for this type) and
+            //    - has wIndex 0 (i.e. no language ID since it's not a string descriptor)
             if desc_ty == DEVICE && desc_index == 0 && langid == 0 {
                 Ok(Request::GetDescriptor {
                     descriptor: Descriptor::Device,
-                    length: wlength,
-                })
-            } else if desc_ty == CONFIGURATION && langid == 0 {
-                Ok(Request::GetDescriptor {
-                    descriptor: Descriptor::Configuration { index: desc_index },
                     length: wlength,
                 })
             } else {
@@ -102,6 +102,7 @@ pub enum Descriptor {
     Device,
 
     /// Configuration descriptor
+    #[cfg(TODO)]
     Configuration {
         /// Index of the descriptor
         index: u8,
@@ -164,6 +165,7 @@ mod tests {
         //                                                    ^
     }
 
+    #[cfg(TODO)]
     #[test]
     fn get_descriptor_configuration() {
         // OK: GET_DESCRIPTOR Configuration 0 [length=9]

--- a/advanced/common/usb/solution-set-configuration.rs
+++ b/advanced/common/usb/solution-set-configuration.rs
@@ -1,5 +1,5 @@
 //! Some USB 2.0 data types
-// NOTE this is a solution to exercise `usb-2`
+// NOTE this is a partial solution to exercise `usb-4`
 
 #![deny(missing_docs)]
 #![deny(warnings)]
@@ -24,6 +24,7 @@ pub enum Request {
 
     /// SET_ADDRESS
     // see section 9.4.6 of the USB specification
+    #[cfg(TODO)]
     SetAddress {
         /// New device address, in the range `1..=127`
         address: Option<Address>,
@@ -31,7 +32,6 @@ pub enum Request {
 
     /// SET_CONFIGURATION
     // see section 9.4.7 of the USB specification
-    #[cfg(TODO)]
     SetConfiguration {
         /// bConfigurationValue to change the device to
         value: Option<NonZeroU8>,
@@ -51,24 +51,18 @@ impl Request {
         windex: u16,
         wlength: u16,
     ) -> Result<Self, ()> {
-        // see table 9-4 (USB specification)
-        const SET_ADDRESS: u8 = 5;
+        // see table 9-4
         const GET_DESCRIPTOR: u8 = 6;
-
+        const SET_CONFIGURATION: u8 = 9;
 
         if bmrequesttype == 0b10000000 && brequest == GET_DESCRIPTOR {
             // see table 9-5
             const DEVICE: u8 = 1;
 
-            // 1. get descriptor type and descriptor index from wValue
             let desc_ty = (wvalue >> 8) as u8;
             let desc_index = wvalue as u8;
             let langid = windex;
 
-            // 2. confirm that the descriptor
-            //    - is of type DEVICE and
-            //    - has descriptor index 0 (i.e. it is the first implemented descriptor for this type) and
-            //    - has wIndex 0 (i.e. no language ID since it's not a string descriptor)
             if desc_ty == DEVICE && desc_index == 0 && langid == 0 {
                 Ok(Request::GetDescriptor {
                     descriptor: Descriptor::Device,
@@ -77,14 +71,10 @@ impl Request {
             } else {
                 Err(())
             }
-        } else if bmrequesttype == 0b00000000 && brequest == SET_ADDRESS {
-            // Set the device address for all future accesses.
-            // (Needed to successfully init when conected to Apple devices)
-            // Section 9.4.6 Set Address of the USB specification explains which values for wvalue,
-            // windex and wlength are valid.
-            if wvalue < 128 && windex == 0 && wlength == 0 {
-                Ok(Request::SetAddress {
-                    address: NonZeroU8::new(wvalue as u8),
+        } else if bmrequesttype == 0b00000000 && brequest == SET_CONFIGURATION {
+            if wvalue < 256 && windex == 0 && wlength == 0 {
+                Ok(Request::SetConfiguration {
+                    value: NonZeroU8::new(wvalue as u8),
                 })
             } else {
                 Err(())
@@ -136,6 +126,24 @@ mod tests {
         //                                                 ^^^^
     }
 
+    #[cfg(TODO)]
+    #[test]
+    fn get_descriptor_configuration() {
+        // OK: GET_DESCRIPTOR Configuration 0 [length=9]
+        assert_eq!(
+            Request::parse(0b1000_0000, 0x06, 0x02_00, 0, 9),
+            Ok(Request::GetDescriptor {
+                descriptor: Descriptor::Configuration { index: 0 },
+                length: 9
+            })
+        );
+
+        // has language ID but shouldn't
+        assert!(Request::parse(0b1000_0000, 0x06, 0x02_00, 1033, 9).is_err());
+        //                                                 ^^^^
+    }
+
+    #[cfg(TODO)]
     #[test]
     fn set_address() {
         // OK: SET_ADDRESS 16
@@ -165,24 +173,6 @@ mod tests {
         //                                                    ^
     }
 
-    #[cfg(TODO)]
-    #[test]
-    fn get_descriptor_configuration() {
-        // OK: GET_DESCRIPTOR Configuration 0 [length=9]
-        assert_eq!(
-            Request::parse(0b1000_0000, 0x06, 0x02_00, 0, 9),
-            Ok(Request::GetDescriptor {
-                descriptor: Descriptor::Configuration { index: 0 },
-                length: 9
-            })
-        );
-
-        // has language ID but shouldn't
-        assert!(Request::parse(0b1000_0000, 0x06, 0x02_00, 1033, 9).is_err());
-        //                                                 ^^^^
-    }
-
-    #[cfg(TODO)]
     #[test]
     fn set_configuration() {
         // OK: SET_CONFIGURATION 1

--- a/embedded-workshop-book/src/setup-stage.md
+++ b/embedded-workshop-book/src/setup-stage.md
@@ -25,7 +25,7 @@ You will also find this information in the `// TODO implement ...` comment in th
 
 To complete the task, proceed like this:
 
-1. **Parse GET_DESCRIPTOR requests:**
+1. **Parse GET_DESCRIPTOR requests:**  
 Modify `Request::parse()` in `advanced/common/usb/src/lib.rs` to recognize a GET_DESCRIPTOR request so that the `get_descriptor_device` test passes. Note that the parser already handles SET_ADDRESS requests.
 
     - check table 9-4 in the USB specification for Request Codes
@@ -34,7 +34,7 @@ Modify `Request::parse()` in `advanced/common/usb/src/lib.rs` to recognize a GET
 
 See `advanced/common/usb/solution-get-descriptor-device.rs` for a solution.
 
-2. **Read incoming request information and pass it to the parser:**
+2. **Read incoming request information and pass it to the parser:**  
 modify `usb-2.rs` to read `USBD` registers and parse the SETUP data when an EPSETUP event is received.
     - for a mapping of register names to the `USBD` API, check the entry for `nrf52840_hal::target::usbd` in the documentation you've created using `cargo doc`
     - remember that we've learned how to read registers in `events.rs`

--- a/embedded-workshop-book/src/setup-stage.md
+++ b/embedded-workshop-book/src/setup-stage.md
@@ -1,6 +1,6 @@
 # USB-2: SETUP Stage
 
-At the end of program `usb-1` we received a EP0SETUP event. This event signals the *end* of the SETUP stage of a control transfer.  The nRF52840 USBD peripheral will automatically receive the SETUP data and store it in the registers BMREQUESTTYPE, BREQUEST, WVALUE{L,H}, WINDEX{L,H} and WLENGTH{L,H}.  
+At the end of program `usb-1` we received a EP0SETUP event. This event signals the *end* of the SETUP stage of a control transfer.  The nRF52840 USBD peripheral will automatically receive the SETUP data and store it in the registers BMREQUESTTYPE, BREQUEST, WVALUE{L,H}, WINDEX{L,H} and WLENGTH{L,H}.
 In `usb-2.rs`, you will find a short description of each register above the variable into which it should be read.
 
 > For in-depth register documentation, refer to sections 6.35.13.31 to 6.35.13.38 of the [nRF52840 Product Specification][nrf product spec].
@@ -25,16 +25,16 @@ You will also find this information in the `// TODO implement ...` comment in th
 
 To complete the task, proceed like this:
 
-1. **Parse GET_DESCRIPTOR requests:**  
+1. **Parse GET_DESCRIPTOR requests:**
 Modify `Request::parse()` in `advanced/common/usb/src/lib.rs` to recognize a GET_DESCRIPTOR request so that the `get_descriptor_device` test passes. Note that the parser already handles SET_ADDRESS requests.
 
     - check table 9-4 in the USB specification for Request Codes
     - remember that you can define binary literals by prefixing them with `0b`
     - you can use bit shifts (`>>`) and casts (`as u8`) to get the high/low bytes of a `u16`
 
-See `advanced/common/usb/src/get-descriptor-device.rs` for a solution.
+See `advanced/common/usb/solution-get-descriptor-device.rs` for a solution.
 
-2. **Read incoming request information and pass it to the parser:**  
+2. **Read incoming request information and pass it to the parser:**
 modify `usb-2.rs` to read `USBD` registers and parse the SETUP data when an EPSETUP event is received.
     - for a mapping of register names to the `USBD` API, check the entry for `nrf52840_hal::target::usbd` in the documentation you've created using `cargo doc`
     - remember that we've learned how to read registers in `events.rs`
@@ -54,5 +54,5 @@ INFO:usb_2 -- Goal reached; move to the next section
 
 `wlength` / `length` can vary depending on the OS, USB port (USB 2.0 vs USB 3.0) or the presence of a USB hub so you may see a different value.
 
-You can find a solution to step 1. in `advanced/common/usb/get-descriptor-device.rs`.  
+You can find a solution to step 1. in `advanced/common/usb/solution-get-descriptor-device.rs`.
 You can find a solution to step 2. in `advanced/firmware/src/bin/usb-2-solution.rs`.

--- a/embedded-workshop-book/src/supporting-standard-requests.md
+++ b/embedded-workshop-book/src/supporting-standard-requests.md
@@ -11,7 +11,7 @@ For each green test, you can extend `usb-4.rs` to handle the new requests your p
 
 If you need a reference, you can find solutions to parsing `GET_DESCRIPTOR Configuration` and `SET_CONFIGURATION` requests in the following files:
 
-- `advanced/common/src/get-descriptor-configuration.rs`
-- `advanced/common/src/set-configuration.rs`
+- `advanced/common/usb/solution-get-descriptor-configuration.rs`
+- `advanced/common/usb/solution-set-configuration.rs`
 
-Each file contains just enough code to parse the request in its name and the `GET_DESCRIPTOR Device` request. So you can refer to `set-configuration.rs` without getting "spoiled" about how to parse the `SET_CONFIGURATION` request.
+Each file contains just enough code to parse the request in its name and the `GET_DESCRIPTOR Device` and `SET_ADDRESS` requests. So you can refer to `solution-get-descriptor-configuration.rs` without getting "spoiled" about how to parse the `SET_CONFIGURATION` request.


### PR DESCRIPTION
also put them outside the `src` directory so people don't think they are modules