### PR TITLE
Book: Time & Logging

### DIFF
--- a/embedded-workshop-book/src/time.md
+++ b/embedded-workshop-book/src/time.md
@@ -11,3 +11,5 @@ This program will blink (turn on and off) one of the LEDs on the board. The time
 The other time related API exposed by the `dk` HAL is the `dk::uptime` function. This function returns the time that has elapsed since the call to the `dk::init` function. This function is used in the program to log the time of each LED toggle operation.
 
 ✅ Try changing the `Duration` value passed to `Timer.wait`. Try values larger than one second and smaller than one second. What values of `Duration` make the blinking imperceptible?
+
+❗If you set the duration to below 100ms, try removing the `log::info!` command in the loop. Too much logging will fill the logging buffer and cause the loop to slow down, resulting in the blink frequency to reduce after a while.


### PR DESCRIPTION
I would like to add a clarifying note into the *Time* section of the beginner's handbook emphasizing how excessive logging can influence the running behavior of the program.

---
From chat:

me: 
> BTW, is it a known defect in the instructions for the "blinky.rs" code, where the loop behavior changes significantly if you remove the logging?
> Reproduce: [formatted]
>  (1) Set the timer to 20ms,
>  (2) Keep log statement,
>  (3) run,
>  (4) observe the LED blinking rapidly but after a while start to "stutter" and blink much less frequently?.
>  (5) Remove the log statement (in the loop),
>  (6) run again,
>  (7) Observe consistent blinking
> 
> This is obvious to me that it would happen. It's just not mentioned in the docs, and 20ms is the threshold where you can still see the blinking, so I guess a lot of people would observe this.

jschievink: 
> probably not intended


