### PR TITLE
Update entry on building program in workshop book

### DIFF
--- a/embedded-workshop-book/src/building-program.md
+++ b/embedded-workshop-book/src/building-program.md
@@ -5,7 +5,7 @@ The default in a Cargo project is to compile for the host (native compilation). 
 ``` text
 # .cargo/config
 [build]
-target = "thumbv7em-none-eabi" # = ARM Cortex-M4
+target = "thumbv7em-none-eabihf" # = ARM Cortex-M4
 ```
 
 ✅ Inside the folder `beginner/apps`, use the following command to cross compile the program to the ARM Cortex-M4 architecture.
@@ -14,12 +14,12 @@ target = "thumbv7em-none-eabi" # = ARM Cortex-M4
 $ cargo build --bin hello
 ```
 
-The output of the compilation process will be an ELF (Executable and Linkable Format) file. The file will be placed in the `target/thumbv7em-none-eabi` directory.
+The output of the compilation process will be an ELF (Executable and Linkable Format) file. The file will be placed in the `target/thumbv7em-none-eabihf` directory.
 
-✅ Run `$ file target/thumbv7em-none-eabi/debug/hello` and compare if your output is as expected.
+✅ Run `$ file target/thumbv7em-none-eabihf/debug/hello` and compare if your output is as expected.
 
 Expected output:
 ``` console
-$ file target/thumbv7em-none-eabi/debug/hello
+$ file target/thumbv7em-none-eabihf/debug/hello
 hello: ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, with debug_info, not stripped
 ```


### PR DESCRIPTION
This PR updates the target entry in the "Building an Embedded Program" section of the workshop book.

There was a mismatch between the target `thumbv7em-none-eabi` described in the workshop book section on how to build the program versus the given target in file `beginner/apps/.cargo/config` which contains entry `thumbv7em-none-eabihf`.