### PR TITLE
Update cross compilation target

### DIFF
--- a/boards/dongle/.cargo/config
+++ b/boards/dongle/.cargo/config
@@ -1,8 +1,8 @@
-[target.thumbv7em-none-eabi]
+[target.thumbv7em-none-eabihf]
 runner = "dongle-flash"
 rustflags = [
   "-C", "link-arg=-Tlink.x",
 ]
 
 [build]
-target = "thumbv7em-none-eabi"
+target = "thumbv7em-none-eabihf"

--- a/embedded-workshop-book/src/installation.md
+++ b/embedded-workshop-book/src/installation.md
@@ -114,7 +114,7 @@ Go to [https://rustup.rs](https://rustup.rs/) and follow the instructions.
 **All**: Run this command in a terminal:
 
 ``` console
-$ rustup +stable target add thumbv7em-none-eabi
+$ rustup +stable target add thumbv7em-none-eabihf
 ```
 
 ### ELF analysis tools

--- a/embedded-workshop-book/src/troubleshoot-cargo-run-error.md
+++ b/embedded-workshop-book/src/troubleshoot-cargo-run-error.md
@@ -7,7 +7,7 @@ You may get one of these errors:
 
 ``` console
 $ cargo run --bin usb-4
-Running `probe-run target/thumbv7em-none-eabi/debug/usb-4`
+Running `probe-run target/thumbv7em-none-eabihf/debug/usb-4`
 Error: An error specific to a probe type occured: USB error while taking control over USB device: Access denied (insufficient permissions)
 
 Caused by:
@@ -16,7 +16,7 @@ Caused by:
 
 ``` console
 $ cargo run --bin usb-4
-Running `probe-run target/thumbv7em-none-eabi/debug/usb-4`
+Running `probe-run target/thumbv7em-none-eabihf/debug/usb-4`
 Error: An error specific to a probe type occured: USB error while taking control over USB device: Resource busy
 
 Caused by:


### PR DESCRIPTION
Use the target actually mentioned in the .cargo/config file.

Updated the output in the troubleshooting page and
also updated the target for the board/dongle.