### PR TITLE
dongle-flash: use program header physical address in ELF -> .hex conversion

### DIFF
--- a/tools/dongle-flash/src/main.rs
+++ b/tools/dongle-flash/src/main.rs
@@ -56,7 +56,7 @@ if the red LED was blinking and you got this message then the device wasn't corr
         let mut records = vec![];
         for ph in elf_file.program_iter() {
             if ph.get_type() == Ok(Type::Load) {
-                let start = ph.offset();
+                let start = ph.physical_addr();
 
                 match ph.get_data(&elf_file).map_err(anyhow::Error::msg)? {
                     SegmentData::Undefined(bytes) => {


### PR DESCRIPTION
`offset` returns the offset of the section *in the ELF file*
`physical_address` returns the (load) address of the section on the device
these are not necessarily the same (but usually are)
this part of dongle-flash is not used by the workshop participants as they'll use dongle-flash with
.hex files (produced by the well-tested `objcopy` tool)