### PR TITLE
move tool installation out of tooling check, clarify cd tools

### DIFF
--- a/embedded-workshop-book/src/installation.md
+++ b/embedded-workshop-book/src/installation.md
@@ -150,8 +150,40 @@ Installed package `cargo-bloat v0.9.3` (..)
 
 $ cargo install probe-run
 (..)
-Installed package `probe-run v0.1.3` (..)
+Installed package `probe-run v0.1.8` (..)
 ```
+
+### Workshop tools
+
+The workshop git repository contains custom crates that help you with flashing and debugging the workshops. Depending on the workshop you're attending, you need to install all or some of them.
+
+#### Beginner workshop
+
+Change to the `tools` folder and run these commands *from different terminals so they'll run in parallel*:
+
+```console
+$ cd  embedded-trainings-2020/tools
+$ cargo install --path usb-list
+$ # in a new terminal, for parallelization
+$ cargo install --path dongle-flash
+$ # in a new terminal, for parallelization
+$ cargo install --path serial-term
+$ # in a new terminal, for parallelization
+$ cargo install --path change-channel
+```
+
+Leave the processes running in the background.
+
+#### Advanced workshop
+
+Change to the `tools` folder and run these commands:
+
+```console
+$ cd  embedded-trainings-2020/tools
+$ cargo install --path usb-list
+```
+
+Leave the process running in the background.
 
 ## Python
 

--- a/embedded-workshop-book/src/tooling-check.md
+++ b/embedded-workshop-book/src/tooling-check.md
@@ -22,18 +22,15 @@ nrfutil version 6.1.0
 
 ## More tools
 
-✅ Now let's install some tools shipped with the workshop material.
+✅ Now let's make sure you've installed the tools shipped with the workshop material.
 
 ### Beginner workshop
 
-From the `tools` folder run these commands *from different terminals so they'll run in parallel*:
-
-- `cargo install --path usb-list`
-- `cargo install --path dongle-flash`
-- `cargo install --path serial-term`
-- `cargo install --path change-channel`
-
-Leave the processes running in the background.
+```console
+$  usb-list
+Bus 020 Device 007: ID 1b1c:0a42
+Bus 020 Device 006: ID 1fc9:0132
+```
 
 ### Advanced workshop
 

--- a/embedded-workshop-book/src/tooling-check.md
+++ b/embedded-workshop-book/src/tooling-check.md
@@ -2,7 +2,7 @@
 
 ## Setup check
 
-✅ First, let's check that you have installed all the tools listed in the previous section.
+✅ Let's check that you have installed all the tools listed in the previous section.
 
 ❗ The first two commands *must* return version `0.8.x`
 
@@ -20,22 +20,35 @@ $ nrfutil version
 nrfutil version 6.1.0
 ```
 
-## More tools
-
 ✅ Now let's make sure you've installed the tools shipped with the workshop material.
 
 ### Beginner workshop
 
+Run the commands listed here and see if they produce similar output, i.e. *don't* yield `command not found: ...`
+
 ```console
-$  usb-list
+$ usb-list
 Bus 020 Device 007: ID 1b1c:0a42
 Bus 020 Device 006: ID 1fc9:0132
+(..)
+
+$ dongle-flash
+Error: expected exactly one argument
+
+$ serial-term
+(waiting for the Dongle to be connected)
+
+$ change-channel
+Error: expected exactly one argument
 ```
 
 ### Advanced workshop
 
-From the `tools` folder run these commands *from different terminals so they'll run in parallel*:
+Run the commands listed here and see if they produce similar output, i.e. *don't* yield `command not found: ...`
 
-- `cargo install --path usb-list`
-
-Leave the processes running in the background.
+```console
+$ usb-list
+Bus 020 Device 007: ID 1b1c:0a42
+Bus 020 Device 006: ID 1fc9:0132
+(..)
+```


### PR DESCRIPTION
in the past (most recently: last week) we've had issues with parts of the installation prep being buried in the tooling check (i.e. people finished the perparation chapter and rightfully assumed they were done but there wer surprises eft in the tooling folder).
Additionally, just mentioning that you need to be in `tools/` to install these tools is easy to miss when you#re skimming the instructions in a hurry.

This PR resolves both of these issues.