### PR TITLE
adapt to breaking changes in cortex-m-rtic 0.5.x

### DIFF
--- a/boards/dk/src/lib.rs
+++ b/boards/dk/src/lib.rs
@@ -176,7 +176,7 @@ impl ops::DerefMut for Timer {
 ///
 /// This return an `Err`or if called more than once
 pub fn init() -> Result<Board, ()> {
-    if let  Some(periph) = hal::target::Peripherals::take() {
+    if let Some(periph) = hal::target::Peripherals::take() {
         // NOTE(static mut) this branch runs at most once
         #[cfg(feature = "advanced")]
         static mut EP0IN_BUF: [u8; 64] = [0; 64];
@@ -226,7 +226,7 @@ pub fn init() -> Result<Board, ()> {
         // the preceding `enable_conuter` method consumes the `rtc` value. This is a semantic move
         // of the RTC0 peripheral from this function (which can only be called at most once) to the
         // interrupt handler (where the peripheral is accessed without any synchronization
-        // mechanism) 
+        // mechanism)
         unsafe { NVIC::unmask(Interrupt::RTC0) };
 
         log::debug!("RTC started");


### PR DESCRIPTION
at some point cortex-m-rtic fixed a memory safety bug: RTIC was not marking the
cortex_m::Peripherals singleton as "taken" in its pre-init code. This made it possible to create two
instances of the singleton, e.g. by calling `cortex_m::Peripherals::take` in an RTIC app.

the fix included a breaking change: it makes `Peripherals::take` return `None` from within an RTIC
app. This breaks the use of `dk::init`, which `take`s those `Peripherals`, within an RTIC app and
thus breaks most of the exercises / examples in the advanced workshop

this PR fixes the issue by making `dk::init` not `take` the `Peripherals`. For more details read
in-line comments in the diff