### PR TITLE
Fix nrfutil fix

### DIFF
--- a/embedded-workshop-book/src/installation.md
+++ b/embedded-workshop-book/src/installation.md
@@ -225,7 +225,7 @@ Apply the following 2 patches (can also be done manually by editing these 2 file
  intelhex
  libusb1
 -pc_ble_driver_py >= 0.14.2
-+# pc_ble_driver_py >= 0.14.2
++pc_ble_driver_py
  piccata
  protobuf
  pyserial

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -12,6 +12,7 @@ hidapi = "1.2.2"
 ihex = "1.1.2"
 pids = { path = "../common/pids" }
 rusb = "0.5.5"
-serialport = "3.3.0"
+#serialport = "3.3.0"
+serialport = { git = "https://gitlab.com/spookyvision1/serialport-rs.git", branch = "fix-usb-deprecation"}
 tempfile = "3.2.0"
 xmas-elf = "0.7.0"

--- a/xtask/src/tasks.rs
+++ b/xtask/src/tasks.rs
@@ -198,7 +198,7 @@ pub fn serial_term() -> color_eyre::Result<()> {
         }
     };
 
-    let mut port = serialport::open(&dongle.port_name)?;
+    let mut port = serialport::new(&dongle.port_name, 9600).open()?;
 
     static CONTINUE: AtomicBool = AtomicBool::new(true);
 


### PR DESCRIPTION
instead of entirely removing the pc_ble_driver_py dependency, just relax the version requirement. Because it _is_ needed to run after all.