### PR TITLE
Fix nrfutil fix fix

### DIFF
--- a/embedded-workshop-book/src/installation.md
+++ b/embedded-workshop-book/src/installation.md
@@ -225,7 +225,7 @@ Apply the following 2 patches (can also be done manually by editing these 2 file
  intelhex
  libusb1
 -pc_ble_driver_py >= 0.14.2
-+# pc_ble_driver_py >= 0.14.2
++pc_ble_driver_py
  piccata
  protobuf
  pyserial


### PR DESCRIPTION
instead of entirely removing the pc_ble_driver_py dependency, just relax the version requirement. Because it is needed to run after all. (this fixes our previously broken nrfutil fix)

This is the third attempt at this PR. (so after fixing the PR that fixes our fix, I had to fix it again, hence the branch name)