### PR TITLE
J-Link can also have a PID of 0x0105

### DIFF
--- a/embedded-workshop-book/src/hardware.md
+++ b/embedded-workshop-book/src/hardware.md
@@ -62,7 +62,7 @@ After connecting the DK to your PC/laptop it will show up as:
 
 **Windows**: a removable USB flash drive (named JLINK) and also as a USB Serial Device (COM port) in the Device Manager under the Ports section
 
-**Linux**: a USB device under `lsusb`. The device will have a VID of `0x1366` and a PID of `0x1015`  -- the `0x` prefix will be omitted in the output of `lsusb`:
+**Linux**: a USB device under `lsusb`. The device will have a VID of `0x1366` and a PID of `0x10??` or `0x01??` (`?` is a hex digit)  -- the `0x` prefix will be omitted in the output of `lsusb`:
 
 ``` console
 $ lsusb

--- a/embedded-workshop-book/src/installation.md
+++ b/embedded-workshop-book/src/installation.md
@@ -60,7 +60,7 @@ ATTRS{idVendor}=="1915", ATTRS{idProduct}=="521f", TAG+="uaccess"
 ATTRS{idVendor}=="2020", TAG+="uaccess"
 
 # nRF52840 Development Kit
-ATTRS{idVendor}=="1366", ATTRS{idProduct}=="1015", TAG+="uaccess"
+ATTRS{idVendor}=="1366", ENV{ID_MM_DEVICE_IGNORE}="1", TAG+="uaccess"
 ```
 
 3. Run the following command to make the new udev rules effective

--- a/xtask/src/tasks.rs
+++ b/xtask/src/tasks.rs
@@ -227,7 +227,15 @@ pub fn usb_list() -> color_eyre::Result<()> {
     for dev in rusb::devices()?.iter() {
         let desc = dev.device_descriptor()?;
         let suffix = match (desc.vendor_id(), desc.product_id()) {
-            (0x1366, 0x1015) => " <- J-Link on the nRF52840 Development Kit",
+            (0x1366, pid) => {
+                let higher_byte = pid >> 8;
+                // 0x1015 and 0x0105 are valid PIDs for a J-Link probe
+                if higher_byte == 0x10 || higher_byte == 0x01 {
+                    " <- J-Link on the nRF52840 Development Kit"
+                } else {
+                    ""
+                }
+            }
             (0x1915, 0x521f) => " <- nRF52840 Dongle (in bootloader mode)",
             (0x2020, pids::LOOPBACK) => " <- nRF52840 Dongle (loopback.hex)",
             (0x2020, pids::PUZZLE) => " <- nRF52840 Dongle (puzzle.hex)",


### PR DESCRIPTION
adjust udev rules and `cargo xtask usb-list` accordingly

if running, FreeDesktop's ModemManager can prevent the discovery of the J-Link so set
`ID_MM_DEVICE_IGNORE` (in the udev rule) to prevent that