### PR TITLE
Update probe-run output to newer versions

### DIFF
--- a/boards/dk/src/lib.rs
+++ b/boards/dk/src/lib.rs
@@ -321,8 +321,7 @@ fn RTC0() {
     unsafe { core::mem::transmute::<_, RTC0>(()).events_ovrflw.reset() }
 }
 
-/// Exits the application and prints a backtrace when the program is executed through the `probe-run`
-/// Cargo runner
+/// Exits the application when the program is executed through the `probe-run` Cargo runner
 pub fn exit() -> ! {
     log::info!("`dk::exit() called; exiting ...`");
     // force any pending memory operation to complete before the BKPT instruction that follows

--- a/embedded-workshop-book/src/panicking.md
+++ b/embedded-workshop-book/src/panicking.md
@@ -5,20 +5,28 @@
 This program attempts to index an array beyond its length and this results in a panic.
 
 ``` console
+(HOST) INFO  flashing program (34.79 KiB)
+(HOST) INFO  success!
+────────────────────────────────────────────────────────────────────────────────
 ERROR:panic_log -- panicked at 'index out of bounds: the len is 3 but the index is 3', src/bin/panic.rs:29:13
+────────────────────────────────────────────────────────────────────────────────
 stack backtrace:
-   0: 0x000022f0 - __bkpt
-   1: 0x00002010 - rust_begin_unwind
-   2: 0x00000338 - core::panicking::panic_fmt
-   3: 0x00000216 - core::panicking::panic_bounds_check
-   4: 0x0000016a - panic::bar
-   5: 0x00000158 - panic::foo
-   6: 0x00000192 - panic::__cortex_m_rt_main
-   7: 0x00000178 - main
-   8: 0x0000199e - Reset
+   0: HardFaultTrampoline
+      <exception entry>
+[...]
+   7: panic::bar
+        at src/bin/panic.rs:29:13
+   8: panic::foo
+        at src/bin/panic.rs:22:5
+   9: panic::__cortex_m_rt_main
+        at src/bin/panic.rs:12:5
+  10: main
+        at src/bin/panic.rs:8:1
+[...]
+(HOST) ERROR the program panicked
 ```
 
-In `no_std` programs the behavior of panic is defined using the `#[panic_handler]` attribute. In the example, the *panic handler* is defined in the `panic_log` crate but we can also implement it manually: 
+In `no_std` programs the behavior of panic is defined using the `#[panic_handler]` attribute. In the example, the *panic handler* is defined in the `panic_log` crate but we can also implement it manually:
 
 ✅ Comment out the `panic_log` import and add the following function to the example:
 

--- a/embedded-workshop-book/src/running-from-vsc.md
+++ b/embedded-workshop-book/src/running-from-vsc.md
@@ -14,20 +14,13 @@ Expected output:
 ``` console
 $ cargo run --bin hello
      Running `probe-run --chip nRF52840_xxAA target/thumbv7em-none-eabihf/debug/hello`
-  (HOST) INFO  flashing program (30.09 KiB)
-  (HOST) INFO  success!
+(HOST) INFO  flashing program (34.79 KiB)
+(HOST) INFO  success!
 ────────────────────────────────────────────────────────────────────────────────
 INFO:hello -- Hello, world!
-stack backtrace:
-   0: __bkpt
-   1: hello::__cortex_m_rt_main
-        at src/bin/hello.rs:15
-   2: main
-        at src/bin/hello.rs:8
-   3: ResetTrampoline
-        at $REGISTRY/cortex-m-rt-0.6.13/src/lib.rs:547
-   4: Reset
-        at $REGISTRY/cortex-m-rt-0.6.13/src/lib.rs:550
+────────────────────────────────────────────────────────────────────────────────
+(HOST) INFO  device halted without error
+
 ```
 
 `cargo run` will compile the application and then invoke the `probe-run` tool with its argument set to the path of the output ELF file.

--- a/embedded-workshop-book/src/stack-overflow-protection.md
+++ b/embedded-workshop-book/src/stack-overflow-protection.md
@@ -16,24 +16,24 @@ The `spam()` function allocates data on the stack until the stack boundaries are
 
 ✅ Run `stack_overflow.rs`
 
-You should see output similar to this:
+You should see output similar to this (the program output between the horizontal bars might be missing):
 
 ``` console
-  (...)
-  (HOST) INFO  flashing program (32.68 KiB)
-  (HOST) INFO  success!
+(HOST) INFO  flashing program (35.25 KiB)
+(HOST) INFO  success!
 ────────────────────────────────────────────────────────────────────────────────
 INFO:stack_overflow -- provoking stack overflow...
 INFO:stack_overflow -- address of current `use_stack` at recursion depth 0: 0x2003aec0
 INFO:stack_overflow -- address of current `use_stack` at recursion depth 1: 0x20039e50
 (...)
 INFO:stack_overflow -- address of current `use_stack` at recursion depth 10: 0x20030a60
-INFO:stack_overflow -- address of current `use_stack` at recursionstack backtrace:
+INFO:stack_overflow -- address of current `use_stack` at recursion
+────────────────────────────────────────────────────────────────────────────────
+stack backtrace:
    0: HardFaultTrampoline
       <exception entry>
-   1: ???
-error: the stack appears to be corrupted beyond this point
-  (HOST) ERROR the program has overflowed its stack
+(HOST) WARN  call stack was corrupted; unwinding could not be completed
+(HOST) ERROR the program has overflowed its stack
 ```
 
 ❗️ `flip-link` is a third-party tool, so make sure you've installed it through `cargo install flip-link`


### PR DESCRIPTION
probe-run no longer prints a backtrace when execution halts without error, and the backtrace format changed