### PR TITLE
Remove confusing redundant instruction

### DIFF
--- a/embedded-workshop-book/src/hello-world.md
+++ b/embedded-workshop-book/src/hello-world.md
@@ -2,11 +2,11 @@
 
 In this section, we'll set up the integration in VS Code and run the first program.
 
-✅ Open the `advanced/firmware` folder in VS Code and open the `src/bin/hello.rs` file from the `advanced/apps` folder.
+✅ Open the `advanced/firmware` folder in VS Code and open the `src/bin/hello.rs` file.
 
-> Note: To ensure full Rust-Analyzer support, do not open the whole `embedded-trainings-2020` folder.
+> Note: To ensure full rust-analyzer support, do not open the whole `embedded-trainings-2020` folder.
 
-Give Rust Analyzer some time to analyze the file and its dependency graph. When it's done, a "Run" button will appear over the `main` function. If it doesn't appear on its own, type something in the file, delete and save. This should trigger a re-load.
+Give rust-analyzer some time to analyze the file and its dependency graph. When it's done, a "Run" button will appear over the `main` function. If it doesn't appear on its own, type something in the file, delete and save. This should trigger a re-load.
 
 ✅ Click the "Run" button to run the application on the microcontroller.
 


### PR DESCRIPTION
Addresses some confusion encountered in https://github.com/ferrous-systems/embedded-trainings-2020/issues/185.

Also fixes the spelling of rust-analyzer.