### PR TITLE
Correct Powershell Env setting

### DIFF
--- a/embedded-workshop-book/src/running-from-vsc.md
+++ b/embedded-workshop-book/src/running-from-vsc.md
@@ -12,7 +12,7 @@ $ export DEFMT_LOG=warn
 
 ### PowerShell
 ```console
-$ Env: DEFMT_LOG = "warn"
+$ $Env:DEFMT_LOG = "warn"
 ```
 
 ### Windows


### PR DESCRIPTION
In Powershell env vars are set via 

```powershell
> $Env:DEFMT_LOG = "trace" 
```

Trying to run the example, as formatted prior to this change (in https://embedded-trainings.ferrous-systems.com/running-from-vsc.html#powershell):

```powershell
> Env: DEFMT_LOG = "trace"  
Env: : The term 'Env:' is not recognized as the name of a cmdlet, function, script file, or operable program. 
Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
At line:1 char:1
+ Env: DEFMT_LOG = "trace"
+ ~~~~
    + CategoryInfo          : ObjectNotFound: (Env::String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException
``` 

This is documented in https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_environment_variables?view=powershell-7.2.