### PR TITLE
Add `--erase-all` to `probe-run` invocations

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,13 +18,8 @@ jobs:
     - name: check out repository
       uses: actions/checkout@v2
 
-    - name: set up rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-
-    - name: set up actions.rs
-      uses: actions-rs/cargo@v1
+    - name: Use the latest stable release
+      run: rustup update stable && rustup default stable
 
     - name: cache rust dependencies
       uses: actions/cache@v2

--- a/advanced/firmware/.cargo/config.toml
+++ b/advanced/firmware/.cargo/config.toml
@@ -7,7 +7,7 @@ rustflags = [
 ]
 
 [target.thumbv7em-none-eabihf]
-runner = "probe-run --chip nRF52840_xxAA"
+runner = "probe-run --chip nRF52840_xxAA --erase-all"
 rustflags = [
   "-C", "link-arg=-Tlink.x",
 ]

--- a/beginner/apps/.cargo/config.toml
+++ b/beginner/apps/.cargo/config.toml
@@ -9,7 +9,7 @@ rustflags = [
 [target.thumbv7em-none-eabihf]
 # set custom cargo runner to flash & run on embedded target when we call `cargo run`
 # for more information, check out https://github.com/knurling-rs/probe-run
-runner = "probe-run --chip nRF52840_xxAA"
+runner = "probe-run --chip nRF52840_xxAA --erase-all"
 rustflags = [
   "-C", "link-arg=-Tlink.x",
 ]


### PR DESCRIPTION
Newer models of the nrf52840 need this in order to flash.